### PR TITLE
Use full GOV.UK release and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        default: main
+        type: string
+
+jobs:
+  lint-ruby:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,14 @@ name: Release
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Release
     uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
     secrets:

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "sassc-rails"
 gem "sprockets-rails"
 
 group :development, :test do
+  gem "brakeman", require: false
   gem "debug", platforms: %i[mri windows]
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.4)
     bindex (0.8.1)
+    brakeman (6.0.1)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -522,6 +523,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  brakeman
   debug
   gds-api-adapters
   govuk_app_config


### PR DESCRIPTION
Turns out the release workflow expects a PR-based workflow with no way of overriding, so let's just do this despite the simple nature of this app.