### PR TITLE
Add permissions to read contents

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref_name }}
     permissions:
       id-token: write
+      contents: read
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image


### PR DESCRIPTION
The Github job, build-and-publish-image fails due to permissions issues.

This is preventing a successful deploy.